### PR TITLE
💄 frame the page as a cowboy shot to keep the footer below the fold

### DIFF
--- a/public/common.css
+++ b/public/common.css
@@ -115,14 +115,20 @@
   background-color: #adadf9 !important; /* Bleu France */
 }
 
-/* Sticky footer: main stretches so the footer sits at the bottom of the
-   viewport even on short pages (no magic header/footer pixel heights). */
-body {
+/* Cowboy shot: the page is the subject (header = head, footer = feet) and
+   the first viewport frames it mid-thigh — header + main share exactly one
+   viewport, whatever the header height, and the footer stays out of frame
+   until you scroll. Short content is centered vertically in main. */
+.pc-cowboy-shot {
+  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
 }
 
 main {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }

--- a/src/views/layout.ts
+++ b/src/views/layout.ts
@@ -22,52 +22,54 @@ export function render_layout(title: string, content: string): string {
     <link rel="stylesheet" href="/dsfr/utility/utility.min.css" />
   </head>
   <body>
-    <header role="banner" class="fr-header">
-      <div class="fr-header__body">
-        <div class="fr-container">
-          <div class="fr-header__body-row">
-            <div class="fr-header__brand fr-enlarge-link">
-              <div class="fr-header__brand-top">
-                <div class="fr-header__logo">
-                  <p class="fr-logo">République<br />française</p>
+    <div class="pc-cowboy-shot">
+      <header role="banner" class="fr-header">
+        <div class="fr-header__body">
+          <div class="fr-container">
+            <div class="fr-header__body-row">
+              <div class="fr-header__brand fr-enlarge-link">
+                <div class="fr-header__brand-top">
+                  <div class="fr-header__logo">
+                    <p class="fr-logo">République<br />française</p>
+                  </div>
+                  <div class="fr-header__navbar">
+                    <button
+                      class="fr-btn--menu fr-btn"
+                      data-fr-opened="false"
+                      aria-controls="modal-499"
+                      id="button-500"
+                      title="Menu"
+                    >
+                      Menu
+                    </button>
+                  </div>
                 </div>
-                <div class="fr-header__navbar">
-                  <button
-                    class="fr-btn--menu fr-btn"
-                    data-fr-opened="false"
-                    aria-controls="modal-499"
-                    id="button-500"
-                    title="Menu"
-                  >
-                    Menu
-                  </button>
+                <div class="fr-header__service">
+                  <a href="/" title="Accueil - Dr. Proconnect">
+                    <p class="fr-header__service-title">Docteur Proconnect</p>
+                  </a>
+                  <p class="fr-header__service-tagline">
+                    Consultez vos données de connexion
+                  </p>
                 </div>
-              </div>
-              <div class="fr-header__service">
-                <a href="/" title="Accueil - Dr. Proconnect">
-                  <p class="fr-header__service-title">Docteur Proconnect</p>
-                </a>
-                <p class="fr-header__service-tagline">
-                  Consultez vos données de connexion
-                </p>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="fr-header__menu fr-modal" id="modal-499" aria-labelledby="button-500">
-        <div class="fr-container">
-          <button class="fr-btn--close fr-btn" aria-controls="modal-499" title="Fermer">
-            Fermer
-          </button>
-          <div class="fr-header__menu-links"></div>
+        <div class="fr-header__menu fr-modal" id="modal-499" aria-labelledby="button-500">
+          <div class="fr-container">
+            <button class="fr-btn--close fr-btn" aria-controls="modal-499" title="Fermer">
+              Fermer
+            </button>
+            <div class="fr-header__menu-links"></div>
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
 
-    <main>
-      ${content}
-    </main>
+      <main>
+        ${content}
+      </main>
+    </div>
 
     <footer class="fr-footer" role="contentinfo" id="footer-7361">
       <div class="fr-container">


### PR DESCRIPTION
**Problem**

On short pages (404, errors) the footer floated mid-screen right under the content. The previous sticky-footer flex pinned it inside the first viewport, and a min-height calc(100vh - 171.1px) needed a hardcoded header height that breaks across breakpoints.

**Proposal**

Wrap header + main in a .pc-cowboy-shot container (the page is the subject: header = head, footer = feet, framed mid-thigh) sized to 100dvh. Header height is accounted for automatically, the footer starts exactly at the fold, and short content centers vertically in main.